### PR TITLE
Ignore /page-not-found/ self-processing and improve soft-404 matching

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -58,7 +58,11 @@ jobs:
           from bs4 import BeautifulSoup
 
           WEBSITE_URL = 'https://is.docs.wso2.com/en/latest/'
-          PAGE_NOT_FOUND = f'{WEBSITE_URL}page-not-found'
+          PAGE_NOT_FOUND_PATH = '/en/latest/page-not-found/'
+          PAGE_NOT_FOUND_URLS = (
+              f'{WEBSITE_URL}page-not-found',
+              f'{WEBSITE_URL}page-not-found/',
+          )
           LOCALHOST_PREFIXES = (
               'http://localhost',
               'https://localhost',
@@ -98,11 +102,11 @@ jobs:
                   # - entries found from /page-not-found/ parent pages
                   result_lower = result.lower()
                   should_ignore_result = any(token in result_lower for token in IGNORE_ERROR_TOKENS)
-                  parent_is_page_not_found = PAGE_NOT_FOUND in parentname
+                  parent_is_page_not_found = any(url in parentname for url in PAGE_NOT_FOUND_URLS)
                   if should_ignore_result or parent_is_page_not_found:
                       continue
 
-                  is_soft_404 = PAGE_NOT_FOUND in final_url
+                  is_soft_404 = PAGE_NOT_FOUND_PATH in final_url
                   is_hard_failure = (valid == 'False')
 
                   if is_soft_404 or is_hard_failure:
@@ -129,9 +133,16 @@ jobs:
               # Keep explicit soft-404 table matching so redirected links that
               # end on /page-not-found/ are always included even if linkchecker
               # reports them as Valid: 200 OK.
-              has_soft_404_marker = PAGE_NOT_FOUND in table_str
-              parent_is_page_not_found = f'Parent URL\t{PAGE_NOT_FOUND}' in table_str
-              if (has_known_broken_url or has_soft_404_marker) and not parent_is_page_not_found:
+              has_soft_404_marker = PAGE_NOT_FOUND_PATH in table_str
+              parent_is_page_not_found = any(
+                  parent_url in table_link_values for parent_url in PAGE_NOT_FOUND_URLS
+              )
+              page_is_page_not_found = any(
+                  page_url in table_link_values for page_url in PAGE_NOT_FOUND_URLS
+              )
+              if (has_known_broken_url or has_soft_404_marker) and not (
+                  parent_is_page_not_found or page_is_page_not_found
+              ):
                   broken_tables.append(table)
 
           final_soup = BeautifulSoup('<!DOCTYPE html><html><head></head><body></body></html>', 'html.parser')


### PR DESCRIPTION
### Motivation
- The link checker was producing false positives when the crawler processed the site’s own `/page-not-found` document, so those self-references should be ignored. 
- Soft-404 detection needed to be more robust so genuine redirects to the page-not-found page from other pages (e.g. MCP quick-start links) are still reported while the page-not-found page itself is skipped. 

### Description
- Introduced `PAGE_NOT_FOUND_PATH` and `PAGE_NOT_FOUND_URLS` and replaced brittle substring checks with explicit URL/path matching. 
- CSV-level filtering now skips records whose `parentname` is any of the page-not-found URL variants. 
- Soft-404 detection now checks the canonical path marker (`/en/latest/page-not-found/`) in the `final_url`. 
- HTML table filtering was tightened to skip tables where either the parent URL or the page URL is the page-not-found URL while still surfacing soft-404s redirected from other pages. 

### Testing
- Verified the workflow file exists and size with `python - <<'PY' from pathlib import Path; print(Path('.github/workflows/basic.yml').exists(), Path('.github/workflows/basic.yml').stat().st_size)`, and it succeeded. 
- Verified repository status with `git -C /workspace/greeting-card-manager status --short`, and it succeeded. 
- Staged and committed the updated workflow with `git -C /workspace/greeting-card-manager add .github/workflows/basic.yml && git -C /workspace/greeting-card-manager commit -m "Ignore page-not-found self-links in link report filtering"`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e7381a988320bbab533d3f779b95)