### PR TITLE
Ignore /page-not-found/ parent URLs in basic link checker

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -67,10 +67,7 @@ jobs:
           parsed_website_url = urlparse(WEBSITE_URL)
           base_path = parsed_website_url.path.rstrip('/')
           PAGE_NOT_FOUND_PATH = f'{base_path}/page-not-found/'
-          PAGE_NOT_FOUND_URLS = (
-              f'{WEBSITE_URL}page-not-found',
-              f'{WEBSITE_URL}page-not-found/',
-          )
+          PAGE_NOT_FOUND_PREFIX = f'{parsed_website_url.scheme}://{parsed_website_url.netloc}/en/'
           LOCALHOST_PREFIXES = (
               'http://localhost',
               'https://localhost',
@@ -81,6 +78,15 @@ jobs:
               '429 too many requests',
               'connectionerror',
           )
+
+          def is_page_not_found_url(value: str) -> bool:
+              if not value:
+                  return False
+              normalized_value = value.strip().rstrip('/')
+              return (
+                  normalized_value.startswith(PAGE_NOT_FOUND_PREFIX)
+                  and normalized_value.endswith('/page-not-found')
+              )
 
           broken_urls = set()
           with open('linkchecker-out.csv', 'r', encoding='utf-8', newline='') as csv_file:
@@ -110,7 +116,7 @@ jobs:
                   # - entries found from /page-not-found/ parent pages
                   result_lower = result.lower()
                   should_ignore_result = any(token in result_lower for token in IGNORE_ERROR_TOKENS)
-                  parent_is_page_not_found = any(url in parentname for url in PAGE_NOT_FOUND_URLS)
+                  parent_is_page_not_found = is_page_not_found_url(parentname)
                   if should_ignore_result or parent_is_page_not_found:
                       continue
 
@@ -143,10 +149,10 @@ jobs:
               # reports them as Valid: 200 OK.
               has_soft_404_marker = PAGE_NOT_FOUND_PATH in table_str
               parent_is_page_not_found = any(
-                  parent_url in table_link_values for parent_url in PAGE_NOT_FOUND_URLS
+                  is_page_not_found_url(parent_url) for parent_url in table_link_values
               )
               page_is_page_not_found = any(
-                  page_url in table_link_values for page_url in PAGE_NOT_FOUND_URLS
+                  is_page_not_found_url(page_url) for page_url in table_link_values
               )
               if (has_known_broken_url or has_soft_404_marker) and not (
                   parent_is_page_not_found or page_is_page_not_found


### PR DESCRIPTION
### Motivation
- The link checker produced false positives coming from versioned `/en/<any>/page-not-found/` parent pages, which made valid redirected links appear as broken in reports.

### Description
- Added `PAGE_NOT_FOUND_PREFIX` and a helper `is_page_not_found_url()` to `.github/workflows/basic.yml` to detect `https://<host>/en/<any>/page-not-found` parent pages.
- Updated the CSV filtering logic to skip CSV-reported errors when the `parentname` matches the page-not-found pattern.
- Updated the HTML table filtering to use `is_page_not_found_url()` when deciding whether to exclude report rows that originate from page-not-found pages.

### Testing
- Reviewed the workflow diff with `git diff -- .github/workflows/basic.yml` to confirm the intended changes were applied successfully.
- Verified the modified workflow file appears in the working tree with `git status --short`.
- Inspected the updated workflow contents with `nl -ba .github/workflows/basic.yml` to confirm the new matcher and its usages are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f0924c708320a1b7e3aa4563993c)