### PR TITLE
Improve page-not-found detection in LinkChecker filter

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -56,6 +56,7 @@ jobs:
           cat > filter_script.py << 'PYEOF'
           import csv
           import os
+          import re
           from urllib.parse import urlparse
           from bs4 import BeautifulSoup
 
@@ -67,9 +68,8 @@ jobs:
           parsed_website_url = urlparse(WEBSITE_URL)
           base_path = parsed_website_url.path.rstrip('/')
           PAGE_NOT_FOUND_PATH = f'{base_path}/page-not-found/'
-          PAGE_NOT_FOUND_URLS = (
-              f'{WEBSITE_URL}page-not-found',
-              f'{WEBSITE_URL}page-not-found/',
+          PAGE_NOT_FOUND_PATTERN = re.compile(
+              rf"{re.escape(parsed_website_url.scheme)}://{re.escape(parsed_website_url.netloc)}/en/[^/\s]+/page-not-found/?(?:$|[?#,\s])"
           )
           LOCALHOST_PREFIXES = (
               'http://localhost',
@@ -81,6 +81,11 @@ jobs:
               '429 too many requests',
               'connectionerror',
           )
+
+          def is_page_not_found_url(value: str) -> bool:
+              if not value:
+                  return False
+              return bool(PAGE_NOT_FOUND_PATTERN.search(value.strip()))
 
           broken_urls = set()
           with open('linkchecker-out.csv', 'r', encoding='utf-8', newline='') as csv_file:
@@ -110,7 +115,7 @@ jobs:
                   # - entries found from /page-not-found/ parent pages
                   result_lower = result.lower()
                   should_ignore_result = any(token in result_lower for token in IGNORE_ERROR_TOKENS)
-                  parent_is_page_not_found = any(url in parentname for url in PAGE_NOT_FOUND_URLS)
+                  parent_is_page_not_found = is_page_not_found_url(parentname)
                   if should_ignore_result or parent_is_page_not_found:
                       continue
 
@@ -143,10 +148,10 @@ jobs:
               # reports them as Valid: 200 OK.
               has_soft_404_marker = PAGE_NOT_FOUND_PATH in table_str
               parent_is_page_not_found = any(
-                  parent_url in table_link_values for parent_url in PAGE_NOT_FOUND_URLS
+                  is_page_not_found_url(parent_url) for parent_url in table_link_values
               )
               page_is_page_not_found = any(
-                  page_url in table_link_values for page_url in PAGE_NOT_FOUND_URLS
+                  is_page_not_found_url(page_url) for page_url in table_link_values
               )
               if (has_known_broken_url or has_soft_404_marker) and not (
                   parent_is_page_not_found or page_is_page_not_found


### PR DESCRIPTION
### Motivation

- Make detection of "/page-not-found" redirects more robust by matching varied URL forms with a regex instead of fixed URL strings.
- Replace brittle tuple membership checks with a dedicated helper to avoid false positives/negatives when filtering reported broken links.

### Description

- Added `re` and introduced `PAGE_NOT_FOUND_PATTERN` that builds a regex from the parsed site URL to match `/en/.../page-not-found` variants.
- Added helper function `is_page_not_found_url(value)` and replaced previous tuple membership checks with calls to this function when processing CSV rows and HTML tables.
- Retained existing `PAGE_NOT_FOUND_PATH` soft-404 logic and other ignore rules (localhost prefixes and error tokens).

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f0924c708320a1b7e3aa4563993c)